### PR TITLE
Hhp 14 display incoming fruit on hippo side

### DIFF
--- a/Hungry-Hippo-Game/public/style.css
+++ b/Hungry-Hippo-Game/public/style.css
@@ -11,6 +11,7 @@ body {
     height: 100vh;
     overflow: hidden;
     display: flex;
+    flex-direction: row;
     justify-content: center;
     align-items: center;
 }
@@ -160,4 +161,53 @@ h1 {
   margin-bottom: 1rem;
   text-align: center;
   font-weight: 600;
+}
+
+/* Container around the Phaser game and the indicator */
+.game-container {
+    position: relative;
+    flex: 1;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+#game-container {
+    width: 100%;
+    height: 100%;
+}
+
+/* Indicator box */
+.current-fruit-indicator {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+    padding: 1rem;
+    border: 2px solid rgba(255, 255, 255, 0.87);
+    border-radius: 0.75rem;
+    text-align: center;
+    width: 220px;
+    background-color: #1e293b;
+    z-index: 10; /* On top of game canvas */
+}
+
+/* Image inside indicator */
+.current-fruit-image {
+    width: 80px;
+    height: 80px;
+    object-fit: contain;
+}
+
+/* Fruit name text */
+.current-fruit-name {
+    margin-top: 0.5rem;
+    font-size: 1.25rem;
+    color: #0ea5e9;
+    font-weight: 600;
+}
+
+/* Placeholder text when no fruit is selected */
+.current-fruit-placeholder {
+    font-size: 1rem;
+    color: #94a3b8;
 }

--- a/Hungry-Hippo-Game/src/App.tsx
+++ b/Hungry-Hippo-Game/src/App.tsx
@@ -17,17 +17,10 @@ function App()
 
         if (phaserRef.current)
         {
-            const scene = phaserRef.current.scene;
+            const scene = phaserRef.current.scene as any;
 
-            if (scene)
-            {
-                // Add a new sprite to the current scene at a random position
-                const x = Phaser.Math.Between(64, scene.scale.width - 64);
-                const y = Phaser.Math.Between(64, scene.scale.height - 64);
-    
-                //  `add.sprite` is a Phaser GameObjectFactory method and it returns a Sprite Game Object instance
-                // const star = scene.add.sprite(x, y, 'star');
-    
+            if (scene && typeof scene.startSpawningFruit === 'function') {
+                scene.startSpawningFruit();
             }
         }
     }
@@ -71,7 +64,7 @@ function App()
                 
                 <div>
                     <div>
-                        <button className="button" onClick={addSprite}>Add New Sprite</button>
+                        <button className="button" onClick={addSprite}>Start</button>
                     </div>
                 </div>
             </div>

--- a/Hungry-Hippo-Game/src/App.tsx
+++ b/Hungry-Hippo-Game/src/App.tsx
@@ -44,13 +44,35 @@ function App()
        });
     };
 
+    // Get the current selected fruit (top of stack)
+    const currentFruit = fruitStack.length > 0 ? fruitStack[0] : null;
+
     return (
         <div id="app">
             <AacInterface onFruitSelected={handleSelectedFruit}/>
-            <PhaserGame ref={phaserRef} />
-            <div>
+            <div className="game-container">
+                <PhaserGame ref={phaserRef} />
+                
+                <div className="current-fruit-indicator">
+                    <h3>Current Fruit to Eat:</h3>
+                    {currentFruit ? (
+                        <>
+                            <img
+                                src={currentFruit.imagePath}
+                                alt={currentFruit.name}
+                                className="current-fruit-image"
+                            />
+                            <p className="current-fruit-name">{currentFruit.name}</p>
+                        </>
+                    ) : (
+                        <p className="current-fruit-placeholder">No Fruit Selected</p>
+                    )}
+                </div>
+                
                 <div>
-                    <button className="button" onClick={addSprite}>Add New Sprite</button>
+                    <div>
+                        <button className="button" onClick={addSprite}>Add New Sprite</button>
+                    </div>
                 </div>
             </div>
         </div>

--- a/Hungry-Hippo-Game/src/game/scenes/Game.ts
+++ b/Hungry-Hippo-Game/src/game/scenes/Game.ts
@@ -6,6 +6,8 @@ export class Game extends Scene
     private fruits: Phaser.Physics.Arcade.Group;
     private fruitKeys = ['apple', 'banana', 'cherry', 'grape'];
 
+    private lanePositions = [256, 512, 768]; // tweak as needed
+
     constructor ()
     {
         super('Game');
@@ -14,11 +16,9 @@ export class Game extends Scene
     preload ()
     {
         this.load.setPath('assets');
-        
 
-        // Background and logo
+        // Background
         this.load.image('background', 'squareTiles.png');
-        this.load.image('logo', 'logo.png');
 
         // Fruit images
         this.load.image('apple', 'apple.png');
@@ -55,18 +55,21 @@ export class Game extends Scene
     }
 
     spawnFruit() {
-        // Random fruit key
+        // Random lane position
+        const randomLaneX = Phaser.Utils.Array.GetRandom(this.lanePositions);
+
+        // Random fruit type
         const randomKey = Phaser.Utils.Array.GetRandom(this.fruitKeys);
 
         // Random position within game canvas
         const x = Phaser.Math.Between(50, 974);
 
         // Fruit spawned from top
-        const fruit = this.fruits.create(x, 0, randomKey) as Phaser.Physics.Arcade.Image;
+        const fruit = this.fruits.create(randomLaneX, 0, randomKey) as Phaser.Physics.Arcade.Image;
         fruit.setScale(0.25); // Fruit 25% of original size
 
         // Gravity
-        fruit.setVelocityY(400); // Will move 500 pixels/sec down
+        fruit.setVelocityY(750); // Will move 750 pixels/sec down
         fruit.setBounce(0.2); // Slight bounce at bottom but used to trigger falling
         fruit.setCollideWorldBounds(true);
     }

--- a/Hungry-Hippo-Game/src/game/scenes/Game.ts
+++ b/Hungry-Hippo-Game/src/game/scenes/Game.ts
@@ -5,8 +5,9 @@ export class Game extends Scene
 {
     private fruits: Phaser.Physics.Arcade.Group;
     private fruitKeys = ['apple', 'banana', 'cherry', 'grape'];
-
     private lanePositions = [256, 512, 768]; // tweak as needed
+
+    private fruitSpawnTimer: Phaser.Time.TimerEvent; // store timer reference
 
     constructor ()
     {
@@ -41,17 +42,21 @@ export class Game extends Scene
 
         // Initialize physics for "fruit" group
         this.fruits = this.physics.add.group();
-
-        // Spawning fruit with a delay
-        this.time.addEvent({
-            delay: 1500,
-            callback: this.spawnFruit,
-            callbackScope: this,
-            loop: true
-        })
         
         EventBus.emit('current-scene-ready', this);
     
+    }
+
+    // Starts the timer to spawn fruits
+    public startSpawningFruit() {
+        if (!this.fruitSpawnTimer) {
+            this.fruitSpawnTimer = this.time.addEvent({
+                delay: 1500,
+                callback: this.spawnFruit,
+                callbackScope: this,
+                loop: true
+            });
+        }
     }
 
     spawnFruit() {
@@ -60,9 +65,6 @@ export class Game extends Scene
 
         // Random fruit type
         const randomKey = Phaser.Utils.Array.GetRandom(this.fruitKeys);
-
-        // Random position within game canvas
-        const x = Phaser.Math.Between(50, 974);
 
         // Fruit spawned from top
         const fruit = this.fruits.create(randomLaneX, 0, randomKey) as Phaser.Physics.Arcade.Image;


### PR DESCRIPTION
Implemented:
- Fruit indicator in the top right corner that shows what fruit the AAC user recently selected
- Fruit to spawn in separate lanes (for each hippo) - currently 3 lanes
- Repurposed the "Add New Sprite" button to "Start" so the fruit starts spawning and falling

Added/Removed:
- Added CSS styling for fruit indicator
- Removed auto fruit spawning at launch (must click "Start" button now)