### PR TITLE
Unit tests for LandingPage, PresenterPage, RoleSelection

### DIFF
--- a/Hungry-Hippo-Game/src/pages/LandingPage/LandingPage.test.tsx
+++ b/Hungry-Hippo-Game/src/pages/LandingPage/LandingPage.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import LandingPage from './LandingPage';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+vi.mock('react-router-dom', () => {
+  const actual = vi.importActual('react-router-dom') as object;
+  return {
+    ...actual,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
+const mockedNavigate = vi.fn();
+
+/**
+ * This test verifies that when the user clicks the "No code? Create new game!" button
+ * on the LandingPage component, a session creation request is sent to the backend
+ * and the user is navigated to the Presenter view using the returned session ID.
+ */
+describe('The host device sends a session creation request ', () => {
+  beforeEach(() => {
+    mockedNavigate.mockReset();
+
+  });
+
+  it('sends a session creation request when "No code? Create new game!" is clicked', async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ sessionId: 'ABCDE' }),
+      })
+    ) as any;
+
+    render(<LandingPage />);
+
+    const createGameButton = screen.getByText(/No code\? Create new game!/i);
+    fireEvent.click(createGameButton);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('http://localhost:4000/create-session', expect.any(Object));
+      expect(mockedNavigate).toHaveBeenCalledWith('/Presenter/ABCDE');
+    });
+
+    (global.fetch as any).mockRestore?.();
+  });
+});

--- a/Hungry-Hippo-Game/src/pages/PresenterPage/Presenter.test.tsx
+++ b/Hungry-Hippo-Game/src/pages/PresenterPage/Presenter.test.tsx
@@ -1,0 +1,55 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Presenter from './Presenter';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
+const mockedNavigate = vi.fn();
+
+/**
+ * This test suite verifies the behavior of the Presenter component:
+ * - It ensures the session ID (game code) is displayed clearly to the host.
+ * - It checks that clicking the "Cancel New Game" button navigates the host back to the landing page.
+ */
+describe('Presenter', () => {
+  it('displays the room code clearly on the host device', () => {
+    const testSessionId = 'ABCDE';
+
+    render(
+      <MemoryRouter initialEntries={[`/Presenter/${testSessionId}`]}>
+        <Routes>
+          <Route path="/Presenter/:sessionId" element={<Presenter />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      `Game Code: ${testSessionId}`
+    );
+  });
+
+  it('navigates back to landing page when cancel button is clicked', () => {
+    const testSessionId = 'ABCDE';
+
+    render(
+      <MemoryRouter initialEntries={[`/Presenter/${testSessionId}`]}>
+        <Routes>
+          <Route path="/Presenter/:sessionId" element={<Presenter />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const cancelButton = screen.getByRole('button', { name: /cancel new game/i });
+    fireEvent.click(cancelButton);
+
+    expect(mockedNavigate).toHaveBeenCalledWith('/');
+  });
+});

--- a/Hungry-Hippo-Game/src/pages/RoleSelection/RoleSelect.test.tsx
+++ b/Hungry-Hippo-Game/src/pages/RoleSelection/RoleSelect.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import RoleSelect from './RoleSelect';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, vi, beforeEach, test } from 'vitest';
+
+const mockedNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<any>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockedNavigate,
+    useParams: () => ({ sessionId: 'ABCDE' }),
+    useLocation: () => ({
+      state: { userId: 'testUser' },
+      pathname: '/role-select/ABCDE',
+    }),
+  };
+});
+
+/**
+ * This test ensures that when a user selects a role and proceeds,
+ * the role and userId are properly sent to the backend and the user
+ * is added to the session list in the database before being navigated
+ * to the game page.
+ */
+describe('RoleSelect Component', () => {
+  beforeEach(() => {
+    mockedNavigate.mockReset();
+    vi.spyOn(global, 'fetch').mockClear();
+  });
+
+  test('Players and AAC users are listed in the database once joined', async () => {
+    vi.spyOn(global, 'fetch').mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            sessions: {
+              ABCDE: [
+                { userId: 'User630', role: 'Hippo Player' },
+                { userId: 'testUser', role: 'Hippo Player' },
+              ],
+            },
+          }),
+      } as Response)
+    );
+
+    render(
+      <MemoryRouter initialEntries={['/role-select/ABCDE']}>
+        <Routes>
+          <Route path="/role-select/:sessionId" element={<RoleSelect />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByRole('combobox'), {
+      target: { value: 'Hippo Player' },
+    });
+
+    fireEvent.click(screen.getByText('Next'));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://localhost:4000/update-role',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            sessionId: 'ABCDE',
+            userId: 'testUser',
+            role: 'Hippo Player',
+          }),
+        })
+      );
+
+      expect(mockedNavigate).toHaveBeenCalledWith('/gamepage/ABCDE/testUser');
+    });
+  });
+});


### PR DESCRIPTION
**Summary:**

- Added unit tests for LandingPage, PresenterPage, RoleSelection
- After running 'npx vitest run' should get passing of 3 test files, 4 tests
- Will need to do some installs if getting compiling errors, my package is different 

<img width="596" alt="Screenshot 2025-06-17 at 12 01 22 AM" src="https://github.com/user-attachments/assets/a7091427-8fdb-4fe7-92ab-6c48673cd457" />
