### PR TITLE
Hhp 69 slow down food remove bounce

### DIFF
--- a/Hungry-Hippo-Game/public/style.css
+++ b/Hungry-Hippo-Game/public/style.css
@@ -246,6 +246,44 @@ h1 {
     color: #94a3b8;
 }
 
+/* Leaderboard */
+.leaderboard {
+    margin-top: 1rem;
+    background: rgba(255, 255, 255, 0.1);
+    border: 1px solid #94a3b8;
+    padding: 0.75rem;
+    border-radius: 0.5rem;
+    font-size: 0.9rem;
+    color: #e2e8f0;
+    text-align: left;
+}
+
+.leaderboard h3 {
+    text-align: center;
+}
+
+.leaderboard ul {
+    list-style: none;
+    padding-left: 0;
+    margin: 0;
+}
+
+.leaderboard li {
+    margin: 0.25rem 0;
+}
+
+.leaderboard-box {
+    position: absolute;
+    top: 300px;
+    right: 20px;
+    width: 220px;
+    background-color: #1e293b;
+    border: 2px solid rgba(255, 255, 255, 0.87);
+    border-radius: 0.75rem;
+    padding: 1rem;
+    z-index: 10;
+}
+
 @media (max-width: 750px) {
 
     .aac-device {

--- a/Hungry-Hippo-Game/sessionAPI.js
+++ b/Hungry-Hippo-Game/sessionAPI.js
@@ -279,6 +279,15 @@ wss.on('connection', (ws) => {
         });
       }
 
+      // Broadcast updated scores to all clients
+      if (data.type === 'SCORE_UPDATE') {
+        const { sessionId, scores } = data.payload;
+        broadcast(sessionId, {
+          type: 'SCORE_UPDATE_BROADCAST',
+          payload: { scores }
+        });
+      }
+
     } catch (error) {
         console.error('WSS Error processing message:', error);
     }

--- a/Hungry-Hippo-Game/sessionAPI.js
+++ b/Hungry-Hippo-Game/sessionAPI.js
@@ -247,16 +247,11 @@ wss.on('connection', (ws) => {
         const { sessionId, food } = data.payload;
         if (sessions[sessionId]) {
           console.log(`WSS Food selected in session ${sessionId}:`, food);
-          const hippoClients = [...sessions[sessionId]].filter(
-            client =>
-              client.readyState === WebSocket.OPEN &&
-              client.role === 'Hippo Player'
-          );
 
-          const responses = hippoClients.map(() => ({
+          const responses = [{
             food,
-            angle: Math.random() * Math.PI * 2 // launch in random direction
-          }));
+            angle: Math.random() * Math.PI * 2
+          }];
           console.log(`WSS Launching ${responses.length} ${food.id}(s) in session ${sessionId}`);
 
           // Sends all as an array in one broadcast

--- a/Hungry-Hippo-Game/src/PhaserGame.tsx
+++ b/Hungry-Hippo-Game/src/PhaserGame.tsx
@@ -82,7 +82,7 @@ export const PhaserGame = forwardRef<IRefPhaserGame, IProps>(function PhaserGame
     {
         EventBus.on('current-scene-ready', (scene_instance: Phaser.Scene) =>
         {
-            const foodKeys = Object.values(AAC_DATA).flat().map(food => food.id);
+            const foodKeys = AAC_DATA.categories.flatMap(cat => cat.foods.map(f => f.id));
             if ('setFoodKeys' in scene_instance && typeof scene_instance['setFoodKeys'] === 'function') {
                 scene_instance['setFoodKeys'](foodKeys);
             }

--- a/Hungry-Hippo-Game/src/components/Leaderboard/Leaderboard.tsx
+++ b/Hungry-Hippo-Game/src/components/Leaderboard/Leaderboard.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+interface LeaderboardProps {
+  scores: Record<string, number>;
+}
+
+const Leaderboard: React.FC<LeaderboardProps> = ({ scores }) => {
+  const sortedEntries = Object.entries(scores).sort((a, b) => b[1] - a[1]);
+
+  return (
+    <div className="leaderboard">
+      <h3>Leaderboard</h3>
+      <ul>
+        {sortedEntries.map(([playerId, score]) => (
+          <li key={playerId}>
+            <strong>{playerId}</strong>: {score}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default Leaderboard;

--- a/Hungry-Hippo-Game/src/contexts/WebSocketContext.tsx
+++ b/Hungry-Hippo-Game/src/contexts/WebSocketContext.tsx
@@ -66,6 +66,11 @@ export const WebSocketProvider: React.FC<{ children: React.ReactNode }> = ({ chi
         setGameStarted(true);
         return;
       }
+
+      if (data.type === 'SCORE_UPDATE_BROADCAST') {
+        EventBus.emit('scoreUpdate', data.payload);
+        return;
+      }
       setLastMessage(data);
     };
 

--- a/Hungry-Hippo-Game/src/game/scenes/Game.ts
+++ b/Hungry-Hippo-Game/src/game/scenes/Game.ts
@@ -237,31 +237,53 @@ export class Game extends Scene {
     food.setCollideWorldBounds(true);
   }
 
-  public addFoodManually(foodKey: string, angle: number) {
+  public addFoodManually(foodKey: string) {
     const centerX = this.scale.width / 2;
     const centerY = this.scale.height / 2;
-    const food = this.foods.create(centerX, centerY, foodKey) as Phaser.Physics.Arcade.Image;
-    food.setScale(0.15);
-    const speed = 300;
-    const velocityX = Math.cos(angle) * speed;
-    const velocityY = Math.sin(angle) * speed;
+    const speed = 100;
 
+    const activeEdges = new Set(Object.values(this.edgeAssignments));
 
-    
-    const degrees = Phaser.Math.RadToDeg(angle);
-        
-    let direction = '';
-    if (degrees >= 45 && degrees < 135) direction = 'down';
-    else if (degrees >= 135 && degrees < 225) direction = 'left';
-    else if (degrees >= 225 && degrees < 315) direction = 'up';
-    else direction = 'right';
-    console.log(`[SPAWN] ${foodKey} launched ${direction} (${degrees.toFixed(0)}°)`); // Logs direction food is launched
+      activeEdges.forEach((edge) => {
+        const food = this.foods.create(centerX, centerY, foodKey) as Phaser.Physics.Arcade.Image;
+        food.setScale(0.15);
+        food.setBounce(0);
+        food.setCollideWorldBounds(false);
+        food.setDamping(false);
+        food.setDrag(0);
 
-    food.setVelocity(velocityX, velocityY);
-    food.setBounce(1, 1);
-    food.setCollideWorldBounds(true);
-    food.setDamping(false);
-    food.setDrag(0);
+        let targetX = centerX;
+        let targetY = centerY;
+
+        switch (edge) {
+          case 'top':
+            targetX = Phaser.Math.Between(64, this.scale.width - 64);
+            targetY = 0;
+            break;
+          case 'bottom':
+            targetX = Phaser.Math.Between(64, this.scale.width - 64);
+            targetY = this.scale.height;
+            break;
+          case 'left':
+            targetX = 0;
+            targetY = Phaser.Math.Between(64, this.scale.height - 64);
+            break;
+          case 'right':
+            targetX = this.scale.width;
+            targetY = Phaser.Math.Between(64, this.scale.height - 64);
+            break;
+        }
+
+        const dx = targetX - centerX;
+        const dy = targetY - centerY;
+        const magnitude = Math.sqrt(dx * dx + dy * dy);
+        const velocityX = (dx / magnitude) * speed;
+        const velocityY = (dy / magnitude) * speed;
+
+        food.setVelocity(velocityX, velocityY);
+
+        console.log(`[SPAWN] ${foodKey} → ${edge} at (${targetX.toFixed(0)}, ${targetY.toFixed(0)})`);
+      })
   }
 
   public setTargetFood(foodId: string) {

--- a/Hungry-Hippo-Game/src/game/scenes/Game.ts
+++ b/Hungry-Hippo-Game/src/game/scenes/Game.ts
@@ -237,53 +237,60 @@ export class Game extends Scene {
     food.setCollideWorldBounds(true);
   }
 
-  public addFoodManually(foodKey: string) {
+  public addFoodManually(selectedFoodId: string) {
     const centerX = this.scale.width / 2;
     const centerY = this.scale.height / 2;
     const speed = 100;
 
+    const allFoodIds = this.foodKeys.filter(id => id !== selectedFoodId);
+    const decoyIds = Phaser.Utils.Array.Shuffle(allFoodIds).slice(0, 2); // exactly 2 decoys
+    const foodToSpawn = [selectedFoodId, ...decoyIds]; // 1 real + 2 decoys
+
     const activeEdges = new Set(Object.values(this.edgeAssignments));
 
       activeEdges.forEach((edge) => {
-        const food = this.foods.create(centerX, centerY, foodKey) as Phaser.Physics.Arcade.Image;
-        food.setScale(0.15);
-        food.setBounce(0);
-        food.setCollideWorldBounds(false);
-        food.setDamping(false);
-        food.setDrag(0);
+        foodToSpawn.forEach(foodId => {
+          const food = this.foods.create(centerX, centerY, foodId) as Phaser.Physics.Arcade.Image;
+          food.setScale(0.15);
+          food.setBounce(0);
+          food.setCollideWorldBounds(false);
+          food.setDamping(false);
+          food.setDrag(0);
 
-        let targetX = centerX;
-        let targetY = centerY;
+          let targetX = centerX;
+          let targetY = centerY;
 
-        switch (edge) {
-          case 'top':
-            targetX = Phaser.Math.Between(64, this.scale.width - 64);
-            targetY = 0;
-            break;
-          case 'bottom':
-            targetX = Phaser.Math.Between(64, this.scale.width - 64);
-            targetY = this.scale.height;
-            break;
-          case 'left':
-            targetX = 0;
-            targetY = Phaser.Math.Between(64, this.scale.height - 64);
-            break;
-          case 'right':
-            targetX = this.scale.width;
-            targetY = Phaser.Math.Between(64, this.scale.height - 64);
-            break;
-        }
+          switch (edge) {
+            case 'top':
+              targetX = Phaser.Math.Between(64, this.scale.width - 64);
+              targetY = 0;
+              break;
+            case 'bottom':
+              targetX = Phaser.Math.Between(64, this.scale.width - 64);
+              targetY = this.scale.height;
+              break;
+            case 'left':
+              targetX = 0;
+              targetY = Phaser.Math.Between(64, this.scale.height - 64);
+              break;
+            case 'right':
+              targetX = this.scale.width;
+              targetY = Phaser.Math.Between(64, this.scale.height - 64);
+              break;
+          }
 
-        const dx = targetX - centerX;
-        const dy = targetY - centerY;
-        const magnitude = Math.sqrt(dx * dx + dy * dy);
-        const velocityX = (dx / magnitude) * speed;
-        const velocityY = (dy / magnitude) * speed;
+          const dx = targetX - centerX;
+          const dy = targetY - centerY;
+          const magnitude = Math.sqrt(dx * dx + dy * dy);
+          const velocityX = (dx / magnitude) * speed;
+          const velocityY = (dy / magnitude) * speed;
 
-        food.setVelocity(velocityX, velocityY);
+          food.setVelocity(velocityX, velocityY);
 
-        console.log(`[SPAWN] ${foodKey} → ${edge} at (${targetX.toFixed(0)}, ${targetY.toFixed(0)})`);
+          console.log(`[SPAWN] ${foodId} → ${edge} at (${targetX.toFixed(0)}, ${targetY.toFixed(0)})`);
+        })
       })
+    this.setTargetFood(selectedFoodId);
   }
 
   public setTargetFood(foodId: string) {


### PR DESCRIPTION
Implemented:
- Food to launch directly to active hippo players sides
- Launch food will be a mixture of one correct food (AAC user selected) and 2 decoy food
- Leaderboard that synced hippo players scores

Removed:
- Old food to hippo player launch logic