### PR TITLE
HHP-84-Leaderboard-UI

### DIFF
--- a/Hungry-Hippo-Game/src/components/Leaderboard/Leaderboard.module.css
+++ b/Hungry-Hippo-Game/src/components/Leaderboard/Leaderboard.module.css
@@ -1,0 +1,33 @@
+
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.listItem {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5em;
+  padding: 0.2em 0;
+}
+
+.hippoImage {
+  width: 35px;
+  height: 35px;
+}
+
+.colorName {
+  font-weight: bold;
+}
+
+.youLabel {
+  font-size: 1.3rem;
+}
+
+.colon {
+  margin-right: 0.25rem;
+}

--- a/Hungry-Hippo-Game/src/components/Leaderboard/Leaderboard.tsx
+++ b/Hungry-Hippo-Game/src/components/Leaderboard/Leaderboard.tsx
@@ -1,23 +1,57 @@
 import React from 'react';
+import styles from './Leaderboard.module.css';
 
+/**
+ * Props for the Leaderboard component.
+ * @scores - Map of player IDs to their scores.
+ * @colors - Map of player IDs to their assigned colors.
+ * @userId - The ID of the current user to highlight in the leaderboard.
+ */
 interface LeaderboardProps {
   scores: Record<string, number>;
+  colors: Record<string, string>;
+  userId: string;
 }
 
-const Leaderboard: React.FC<LeaderboardProps> = ({ scores }) => {
+/**
+ * A leaderboard UI component that displays hippo avatars and scores for each player.
+ *
+ * - Sorts players by score (highest first)
+ * - Displays hippo image based on color
+ * - Highlights the current user with "(You)"
+ *
+ * @param props - The props for the component
+ * @returns A rendered list of players with scores and avatars
+ */
+const Leaderboard: React.FC<LeaderboardProps> = ({ scores, colors, userId }) => {
+  // Sort players by descending score
   const sortedEntries = Object.entries(scores).sort((a, b) => b[1] - a[1]);
 
   return (
-    <div className="leaderboard">
-      <h3>Leaderboard</h3>
-      <ul>
-        {sortedEntries.map(([playerId, score]) => (
-          <li key={playerId}>
-            <strong>{playerId}</strong>: {score}
+    <ul className={styles.list}>
+      {sortedEntries.map(([playerId, score]) => {
+        const color = colors[playerId];
+        // uncomment this line to display color
+        // const displayColor = color ? color[0].toUpperCase() + color.slice(1) : playerId;
+
+        return (
+          <li key={playerId} className={styles.listItem}>
+            <img
+              src={`/assets/hippos/${color}Hippo.png`}
+              alt={`${color} Hippo`}
+              className={styles.hippoImage}
+            />
+            <span className={styles.colorName}>
+              {/* uncomment this line to display color */}
+              {/* {displayColor} */}
+              {playerId === userId && <span className={styles.youLabel}> (You)</span>}
+            </span>
+            <span className={styles.colon}>:</span>
+            <span>{score} pts</span>
           </li>
-        ))}
-      </ul>
-    </div>
+        );
+      })}
+    </ul>
   );
 };
 

--- a/Hungry-Hippo-Game/src/pages/PhaserPage/PhaserPage.module.css
+++ b/Hungry-Hippo-Game/src/pages/PhaserPage/PhaserPage.module.css
@@ -37,6 +37,23 @@
   text-align: center;
   width: clamp(160px, 18vw, 220px);
   font-size: clamp(0.8rem, 2vw, 1rem); 
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.7em;
+  margin: 0 auto 1.2rem auto;
+  padding: 0.7em 1.5em;
+  width: clamp(160px, 18vw, 280px);
+  border-radius: 20px;
+  background: linear-gradient(90deg, #fffae3 0%, #b3e4ff 100%);
+  box-shadow: 0 4px 24px 0 rgba(0, 30, 100, 0.12), 0 2px 8px rgba(190, 230, 255, 0.09);
+  border: 2.5px solid #f8f8f7;
+  font-family: 'Baloo 2', 'Comic Sans MS', 'Arial Rounded MT Bold', Arial, sans-serif;
+  font-size: 1.3rem;
+  color: #163153;
+  user-select: none;
+  transition: box-shadow 0.2s;
 }
 
 .foodImage {


### PR DESCRIPTION
Summary:
- Lighthouse accessibility is 100 
- leaderboard now displays hippo icon, instead of UserID
- leaderboard displays current user as "You" next to their hippo
- updated background styling to current fruit and leaderboard sections

<img width="1429" height="719" alt="Screenshot 2025-07-25 at 4 50 44 PM" src="https://github.com/user-attachments/assets/21432496-9f47-442e-aa8e-95b0aebab83a" />
<img width="1137" height="728" alt="Screenshot 2025-07-25 at 7 04 40 PM" src="https://github.com/user-attachments/assets/63c3868e-8d72-4e96-b46c-9a081a7ee080" />

