### PR TITLE
HHP-111-UI-Cutoff

### DIFF
--- a/Hungry-Hippo-Game/src/pages/PhaserPage/PhaserPage.module.css
+++ b/Hungry-Hippo-Game/src/pages/PhaserPage/PhaserPage.module.css
@@ -20,12 +20,22 @@
   overflow: hidden;
 }
 
+.sidebarWrapper {
+  flex: 0 0 auto;
+  padding-right: 1rem; 
+}
+
 .sidebar {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
   justify-content: flex-start;
   align-items: center;
+}
+
+.sidebar h3,
+.sidebar p {
+  margin: 0.2rem;
 }
 
 .currentFood, .leaderboardBox, .timerBox, .spectatorBanner {


### PR DESCRIPTION
Summary:
- Issue was leaderboard, current fruit would get cropped off on the side when <1300px
- Leaderboard would get cropped on bottom when on smaller screen and 4 hippos playing
- Added padding
- Updated margin of sidebar to decrease spacing